### PR TITLE
Parse hashtags starting with numbers, but ending in alphanumeric characters

### DIFF
--- a/inline.go
+++ b/inline.go
@@ -22,7 +22,7 @@ import (
 var (
 	urlRe    = `((https?|ftp):\/\/|\/)[-A-Za-z0-9+&@#\/%?=~_|!:,.;\(\)]+`
 	anchorRe = regexp.MustCompile(`^(<a\shref="` + urlRe + `"(\stitle="[^"<>]+")?\s?>` + urlRe + `<\/a>)`)
-	hashRe   = regexp.MustCompile(`#([\p{L}\p{M}][\p{L}\p{M}\d]*)`)
+	hashRe   = regexp.MustCompile(`#(([\d]+[\p{L}\p{M}]+[\p{L}\p{M}\d]*)|([\p{L}\p{M}][\p{L}\p{M}\d]*))`)
 )
 
 // Functions to parse text within a block


### PR DESCRIPTION
Previously, a hashtag like `#100days` wasn't correctly parsed. This fixes that, while still preventing accidental parsing of number-only "hashtags" like `#100`.